### PR TITLE
a new push based BIO

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,14 @@
 # Revision history for Z-IO
 
+## 0.7.2.0  -- 2020-04-20
+
+This is an experimental version to test new 'BIO' module.
+
+* Rewrite `Z.IO.BIO` module, now `BIO` is push based.
+* Remove `zipSource/zipBIO`, add `stepBIO/stepBIO_/runBIO_`.
+* Add `ungroupingNode`, change `newGroupingNode` to use `Vector`.
+* Rename `EOF` exception to `UnexpectedEOF` to avoid the clash with `EOF` pattern.
+
 ## 0.7.1.0  -- 2020-03-16
 
 * Use `CPtr` from Z-Data instead of `ForeignPtr`.

--- a/Z-IO.cabal
+++ b/Z-IO.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               Z-IO
-version:            0.7.1.0
+version:            0.7.2.0
 synopsis:           Simple and high performance IO toolkit for Haskell
 description:
   Simple and high performance IO toolkit for Haskell, including

--- a/Z/IO/BIO.hs
+++ b/Z/IO/BIO.hs
@@ -591,15 +591,14 @@ newMagicSplitter magic = do
         case mx of
             Just bs -> do
                 trailing <- readIORef trailingRef
-                let chunk =  trailing `V.append` bs
-                    loop bs = case V.elemIndex magic bs of
+                let loop chunk = case V.elemIndex magic chunk of
                         Just i -> do
                             -- TODO: looping
-                            let (line, rest) = V.splitAt (i+1) bs
+                            let (line, rest) = V.splitAt (i+1) chunk
                             k (Just line)
                             loop rest
-                        _ -> writeIORef trailingRef bs
-                loop
+                        _ -> writeIORef trailingRef chunk
+                loop (trailing `V.append` bs)
             _ -> do
                 chunk <- readIORef trailingRef
                 unless (V.null chunk) $ do

--- a/Z/IO/BIO/Zlib.hsc
+++ b/Z/IO/BIO/Zlib.hsc
@@ -184,7 +184,7 @@ newCompress (CompressConfig level windowBits memLevel dict strategy bufSiz) = do
                         when (osiz /= 0) $ do
                             oarr <- A.unsafeFreezeArr =<< readIORef bufRef
                             k (Just (V.PrimVector oarr 0 osiz))
-                        k Nothing
+                        k EOF
             in loop)
 
 -- | Reset compressor's state so that related 'BIO' can be reused.
@@ -278,7 +278,7 @@ newDecompress (DecompressConfig windowBits dict bufSiz) = do
                         when (osiz /= 0) $ do
                             oarr <- A.unsafeFreezeArr =<< readIORef bufRef
                             k (Just (V.PrimVector oarr 0 osiz))
-                        k Nothing
+                        k EOF
             in loop)
 
 -- | Reset decompressor's state so that related 'BIO' can be reused.

--- a/Z/IO/Exception.hs
+++ b/Z/IO/Exception.hs
@@ -43,7 +43,7 @@ module Z.IO.Exception
   , NoSuchThing(..)
   , ResourceBusy(..)
   , ResourceExhausted(..)
-  , EOF(..)
+  , UnexpectedEOF(..)
   , IllegalOperation(..)
   , PermissionDenied(..)
   , UnsatisfiedConstraints(..)
@@ -119,7 +119,7 @@ IOE(AlreadyExists)
 IOE(NoSuchThing)
 IOE(ResourceBusy)
 IOE(ResourceExhausted)
-IOE(EOF)
+IOE(UnexpectedEOF)
 IOE(IllegalOperation)
 IOE(PermissionDenied)
 IOE(UnsatisfiedConstraints)
@@ -261,7 +261,7 @@ throwUV e = do
 throwUVError :: CInt -> IOEInfo -> IO a
 {-# INLINABLE throwUVError #-}
 throwUVError e info = case e of
-    UV_EOF             -> throwIO (EOF                     info)
+    UV_EOF             -> throwIO (UnexpectedEOF           info)
     UV_E2BIG           -> throwIO (ResourceExhausted       info)
     UV_EACCES          -> throwIO (PermissionDenied        info)
     UV_EADDRINUSE      -> throwIO (ResourceBusy            info)

--- a/test/Z/IO/BIOSpec.hs
+++ b/test/Z/IO/BIOSpec.hs
@@ -2,6 +2,7 @@
 
 module Z.IO.BIOSpec where
 
+import           Control.Concurrent
 import           Control.Monad
 import qualified Codec.Compression.Zlib as TheZlib
 import           Data.IORef
@@ -23,22 +24,22 @@ spec = describe "BIO" . modifyMaxSize (*10) $ do
     describe "decode . encode === id(Base64)" $
         prop "Base64" $ \ xs ->
             let r = unsafePerformIO $ do
-                    src <- sourceFromList xs
+                    let src = sourceFromList xs
                     (rRef, sink) <- sinkToList
                     enc <- newBase64Encoder
                     dec <- newBase64Decoder
                     runBIO $ src >|> enc >|> dec >|> sink
-                    readIORef rRef
+                    takeMVar rRef
             in V.concat r === V.concat xs
 
     describe "decode . encode === id(Hex)" $ do
         prop "Hex" $ \ xs upper ->
             let r = unsafePerformIO $ do
-                    src <- sourceFromList xs
+                    let src = sourceFromList xs
                     (rRef, sink) <- sinkToList
                     let enc = hexEncoder upper
                     dec <- newHexDecoder
                     runBIO $ src >|> enc >|> dec >|> sink
-                    readIORef rRef
+                    takeMVar rRef
             in V.concat r === V.concat xs
 


### PR DESCRIPTION
This new BIO definition will:

+ Return pushed streams instead of pulled ones.
+ Give pure `appendSource/concatSource`, `joinSink/fuseSink`.
+ Remove zipping, remove `push/pull`.

This will fix the previous `pull` 's buggy semantics, at the price of not being able to consume sources step by step.